### PR TITLE
Daniel's suggestions to texts

### DIFF
--- a/smallactsmanifesto/locale/en/LC_MESSAGES/django.po
+++ b/smallactsmanifesto/locale/en/LC_MESSAGES/django.po
@@ -124,7 +124,7 @@ msgstr "Self-organization"
 
 #: core/templates/index.html:16
 msgid " - leaders emerge, but there should be no owners;"
-msgstr " - leaders emerge, but there should be no owners;"
+msgstr " - leaders come and go, but there should be no owners;"
 
 #: core/templates/index.html:17
 msgid "Example"
@@ -132,7 +132,7 @@ msgstr "Example"
 
 #: core/templates/index.html:17
 msgid " - that's how you must teach, live and learn;"
-msgstr " - that's how you must teach, live and learn;"
+msgstr " - that's how you teach, live and learn;"
 
 #: core/templates/index.html:18
 msgid "Consistency"


### PR DESCRIPTION
Based on feedback from awesome people from Fundación Capital :)

The first one is due to the fact that the term "emerge", without its opposite "submerge", could make you think that once a leader emerged it would stay a leader (therefore running the risk of becoming an owner).

The second one is more obvious: without the "must" it becomes much much more elegant, and implies no moral obligation.

PS: I'm sending this here because I didn't find a way to do it on Transifex. If you merge this and add me to the Transifex team, I can translate them to the other languages as well ;)

Beijos!
